### PR TITLE
Update README.md to make ctrl/caps swap more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,7 +855,7 @@ Changes implemented at my local copy:
 * use mouse only for browsing subgroup Back/ForwardMouseButton, to free Tab
 * change Select All Army to keybind to allow group modifiers with Tab (by me Shift+Tab)
 * use Tab as CapsLock group
-* CapsLock is now free to be used as Control modifier with external software
+* CapsLock is now free to be used as Control modifier with external software. Note: you may not be able to use Alt in conjunction with Tab. Consequently, I only have the Ctrl and Shift+Ctrl functions for this control group.
 
 ## Other possible tweaks
 


### PR DESCRIPTION
I was looking to adopt TheCoreLite and I conveniently already swap caps and ctrl on my keyboard. I was running into an issue where I couldn't bind alt+tab, alt+shift+tab, etc and was confused about how you did it. I think this clarification makes it clear.